### PR TITLE
sdm710-common: rootdir: Clean up duplicate "noatime" mount options

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -17,8 +17,8 @@
 
 /dev/block/bootdevice/by-name/cache                     /cache                   ext4    nosuid,noatime,nodev,barrier=1                       wait
 
-/dev/block/bootdevice/by-name/userdata                  /data                    f2fs    noatime,nosuid,noatime,nodev,lazytime,fsync_mode=nobarrier         wait,check,fileencryption=ice,quota,reservedsize=128M
-/dev/block/bootdevice/by-name/userdata                  /data                    ext4    noatime,nosuid,noatime,nodev,barrier=1,noauto_da_alloc,lazytime    wait,check,fileencryption=ice,quota,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata                  /data                    f2fs    noatime,nosuid,nodev,lazytime,fsync_mode=nobarrier         wait,check,fileencryption=ice,quota,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata                  /data                    ext4    noatime,nosuid,nodev,barrier=1,noauto_da_alloc,lazytime    wait,check,fileencryption=ice,quota,reservedsize=128M
 
 /dev/block/bootdevice/by-name/bluetooth                 /vendor/bt_firmware      vfat    ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:bt_firmware_file:s0 wait
 /dev/block/bootdevice/by-name/dsp                       /vendor/dsp              ext4    ro,nosuid,nodev,barrier=1                            wait


### PR DESCRIPTION
* Keeping it won't affect anything, removing it just looks cleaner

Fixes: 09d8de3 ("sdm710-common: Initial rootdir")
Change-Id: I065b04a7850b332ca521300a54e7f4cea5936758